### PR TITLE
Fix for issue #12: add joint name config files to support pkgs

### DIFF
--- a/kuka_kr120_support/CMakeLists.txt
+++ b/kuka_kr120_support/CMakeLists.txt
@@ -11,7 +11,7 @@ if (CATKIN_ENABLE_TESTING)
   roslaunch_add_file_check(test/roslaunch_test.xml)
 endif()
 
-foreach(dir launch meshes urdf)
+foreach(dir config launch meshes urdf)
   install(
     DIRECTORY ${dir}/
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})

--- a/kuka_kr120_support/config/joint_names_kr120r2500pro.yaml
+++ b/kuka_kr120_support/config/joint_names_kr120r2500pro.yaml
@@ -1,0 +1,1 @@
+controller_joint_names: ['joint_a1', 'joint_a2', 'joint_a3', 'joint_a4', 'joint_a5', 'joint_a6']

--- a/kuka_kr210_support/CMakeLists.txt
+++ b/kuka_kr210_support/CMakeLists.txt
@@ -11,7 +11,7 @@ if (CATKIN_ENABLE_TESTING)
   roslaunch_add_file_check(test/roslaunch_test.xml)
 endif()
 
-foreach(dir launch meshes urdf)
+foreach(dir config launch meshes urdf)
   install(
     DIRECTORY ${dir}/
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})

--- a/kuka_kr210_support/config/joint_names_kr210l150.yaml
+++ b/kuka_kr210_support/config/joint_names_kr210l150.yaml
@@ -1,0 +1,1 @@
+controller_joint_names: ['joint_1', 'joint_2', 'joint_3', 'joint_4', 'joint_5', 'joint_6']


### PR DESCRIPTION
The KR 120 and KR 210 support pkgs did not provide default `controller_joint_map` config files. These are typically used in variant specific robot driver wrapper launch files.

This PR adds them for the R2500 Pro and the L150.
