### PR TITLE
System clock for stamps, steady clock for intervals

### DIFF
--- a/kuka_rsi_hw_interface/include/kuka_rsi_hw_interface/kuka_hardware_interface.h
+++ b/kuka_rsi_hw_interface/include/kuka_rsi_hw_interface/kuka_hardware_interface.h
@@ -57,11 +57,7 @@
 #include <hardware_interface/robot_hw.h>
 
 // Timers
-//#include <stdlib.h>
-#include <signal.h>
-#include <time.h>
-#include <sched.h>
-#include <sys/mman.h>
+#include <chrono>
 
 // UDP server
 #include <kuka_rsi_hw_interface/udp_server.h>


### PR DESCRIPTION
The call to `clock_gettime(CLOCK_MONOTONIC, &ts)` is not guaranteed to return UNIX time (it returns time since boot on my system for example). We should use ROS time for timestamps and the monotonic/steady clock for intervals. I replaced the timekeeping functions with C++11 code.

Supersedes #41 
