### PR TITLE
Fix for issue #60: remove em-dash to avoid encoding errors

### DIFF
--- a/kuka_resources/urdf/common_colours.xacro
+++ b/kuka_resources/urdf/common_colours.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <!-- colours based on RAL values given in "FAQ – Colours of robot and robot
+  <!-- colours based on RAL values given in "FAQ - Colours of robot and robot
        controller", version "KUKA.Tifs | 2010-01-21 |YM| DefaultColorsRobotAndController.doc",
        downloaded 2015-07-18 from
        http://www.kuka.be/main/cservice/faqs/hardware/DefaultColorsRobotAndController.pdf


### PR DESCRIPTION
The xml file is not a unicode file, which makes `xacro` fail when it encounters the em-dash.
