### PR TITLE
Changed joint names of KR210

### DIFF
--- a/kuka_kr210_support/config/joint_names_kr210l150.yaml
+++ b/kuka_kr210_support/config/joint_names_kr210l150.yaml
@@ -1,1 +1,1 @@
-controller_joint_names: ['joint_1', 'joint_2', 'joint_3', 'joint_4', 'joint_5', 'joint_6']
+controller_joint_names: ['joint_a1', 'joint_a2', 'joint_a3', 'joint_a4', 'joint_a5', 'joint_a6']

--- a/kuka_kr210_support/urdf/kr210l150.urdf
+++ b/kuka_kr210_support/urdf/kr210l150.urdf
@@ -160,42 +160,42 @@
     </collision>
   </link>
   <link name="tool0"/>
-  <joint name="joint_1" type="revolute">
+  <joint name="joint_a1" type="revolute">
     <origin rpy="0 0 0" xyz="-0.00262 0.00097586 0.33099"/>
     <parent link="base_link"/>
     <child link="link_1"/>
     <axis xyz="0 0 1"/>
     <limit effort="0" lower="-3.228859205" upper="3.228859205" velocity="2.146755039"/>
   </joint>
-  <joint name="joint_2" type="revolute">
+  <joint name="joint_a2" type="revolute">
     <origin rpy="0 0 0" xyz="0.35277 -0.037476 0.4192"/>
     <parent link="link_1"/>
     <child link="link_2"/>
     <axis xyz="0 1 0"/>
     <limit effort="0" lower="-0.785398185" upper="1.483529905" velocity="2.007128695"/>
   </joint>
-  <joint name="joint_3" type="revolute">
+  <joint name="joint_a3" type="revolute">
     <origin rpy="0 0 0" xyz="-9.8483E-05 -0.1475 1.2499"/>
     <parent link="link_2"/>
     <child link="link_3"/>
     <axis xyz="0 1 0"/>
     <limit effort="0" lower="-3.66519153" upper="1.134464045" velocity="1.954768816"/>
   </joint>
-  <joint name="joint_4" type="revolute">
+  <joint name="joint_a4" type="revolute">
     <origin rpy="0 0 0" xyz="0.95795 0.184 -0.055059"/>
     <parent link="link_3"/>
     <child link="link_4"/>
     <axis xyz="1 0 0"/>
     <limit effort="0" lower="-6.10865255" upper="6.10865255" velocity="3.124139447"/>
   </joint>
-  <joint name="joint_5" type="revolute">
+  <joint name="joint_a5" type="revolute">
     <origin rpy="0 0 0" xyz="0.542 0 0"/>
     <parent link="link_4"/>
     <child link="link_5"/>
     <axis xyz="0 1 0"/>
     <limit effort="0" lower="-2.181661625" upper="2.181661625" velocity="3.001966396"/>
   </joint>
-  <joint name="joint_6" type="revolute">
+  <joint name="joint_a6" type="revolute">
     <origin rpy="0 0 0" xyz="0.1925 0 0"/>
     <parent link="link_5"/>
     <child link="link_6"/>

--- a/kuka_kr210_support/urdf/kr210l150_macro.xacro
+++ b/kuka_kr210_support/urdf/kr210l150_macro.xacro
@@ -164,42 +164,42 @@
     <link name="${prefix}tool0"/>
 
     <!-- joints -->
-    <joint name="${prefix}joint_1" type="revolute">
+    <joint name="${prefix}joint_a1" type="revolute">
       <origin xyz="-0.00262 0.00097586 0.33099" rpy="0 0 0"/>
       <parent link="${prefix}base_link"/>
       <child link="${prefix}link_1"/>
       <axis xyz="0 0 1"/>
       <limit lower="${-185*deg}" upper="${185*deg}" effort="0" velocity="${123*deg}"/>
     </joint>
-    <joint name="${prefix}joint_2" type="revolute">
+    <joint name="${prefix}joint_a2" type="revolute">
       <origin xyz="0.35277 -0.037476 0.4192" rpy="0 0 0"/>
       <parent link="${prefix}link_1"/>
       <child link="${prefix}link_2"/>
       <axis xyz="0 1 0"/>
       <limit lower="${-45*deg}" upper="${85*deg}" effort="0" velocity="${115*deg}"/>
     </joint>
-    <joint name="${prefix}joint_3" type="revolute">
+    <joint name="${prefix}joint_a3" type="revolute">
       <origin xyz="-9.8483E-05 -0.1475 1.2499" rpy="0 0 0"/>
       <parent link="${prefix}link_2"/>
       <child link="${prefix}link_3"/>
       <axis xyz="0 1 0"/>
       <limit lower="${-210*deg}" upper="${(155-90)*deg}" effort="0" velocity="${112*deg}"/>
     </joint>
-    <joint name="${prefix}joint_4" type="revolute">
+    <joint name="${prefix}joint_a4" type="revolute">
       <origin xyz="0.95795 0.184 -0.055059" rpy="0 0 0"/>
       <parent link="${prefix}link_3"/>
       <child link="${prefix}link_4"/>
       <axis xyz="1 0 0"/>
       <limit lower="${-350*deg}" upper="${350*deg}" effort="0" velocity="${179*deg}"/>
     </joint>
-    <joint name="${prefix}joint_5" type="revolute">
+    <joint name="${prefix}joint_a5" type="revolute">
       <origin xyz="0.542 0 0" rpy="0 0 0"/>
       <parent link="${prefix}link_4"/>
       <child link="${prefix}link_5"/>
       <axis xyz="0 1 0"/>
       <limit lower="${-125*deg}" upper="${125*deg}" effort="0" velocity="${172*deg}"/>
     </joint>
-    <joint name="${prefix}joint_6" type="revolute">
+    <joint name="${prefix}joint_a6" type="revolute">
       <origin xyz="0.1925 0 0" rpy="0 0 0"/>
       <parent link="${prefix}link_5"/>
       <child link="${prefix}link_6"/>


### PR DESCRIPTION
Changed joint names of KR210 to follow naming scheme used in other robots in kuka_experimental. KR210 had joint_1, joint_2, ... but others have joint_a1, joint_a2, ...
