### PR TITLE
kr6: add colours to r900sixx collision geometry.

### DIFF
--- a/kuka_kr6_support/urdf/kr6r900sixx_macro.xacro
+++ b/kuka_kr6_support/urdf/kr6r900sixx_macro.xacro
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:include filename="$(find kuka_resources)/urdf/common_constants.xacro"/>
+  <xacro:include filename="$(find kuka_resources)/urdf/common_materials.xacro"/>
 
   <xacro:macro name="kuka_kr6r900sixx" params="prefix">
     <link name="${prefix}base_link">
@@ -9,6 +10,7 @@
         <geometry>
           <mesh filename="package://kuka_kr6_support/meshes/kr6_agilus/visual/base_link.dae" />
         </geometry>
+        <xacro:material_kuka_pedestal />
       </visual>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -23,6 +25,7 @@
         <geometry>
           <mesh filename="package://kuka_kr6_support/meshes/kr6_agilus/visual/link_1.dae" />
         </geometry>
+        <xacro:material_kuka_orange />
       </visual>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -37,6 +40,7 @@
         <geometry>
           <mesh filename="package://kuka_kr6_support/meshes/kr6r900sixx/visual/link_2.dae"/>
         </geometry>
+        <xacro:material_kuka_orange />
       </visual>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -51,6 +55,7 @@
         <geometry>
           <mesh filename="package://kuka_kr6_support/meshes/kr6_agilus/visual/link_3.dae" />
         </geometry>
+        <xacro:material_kuka_orange />
       </visual>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -65,6 +70,7 @@
         <geometry>
           <mesh filename="package://kuka_kr6_support/meshes/kr6r900sixx/visual/link_4.dae" />
         </geometry>
+        <xacro:material_kuka_orange />
       </visual>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -79,6 +85,7 @@
         <geometry>
           <mesh filename="package://kuka_kr6_support/meshes/kr6_agilus/visual/link_5.dae" />
         </geometry>
+        <xacro:material_kuka_orange />
       </visual>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -93,6 +100,7 @@
         <geometry>
           <mesh filename="package://kuka_kr6_support/meshes/kr6_agilus/visual/link_6.dae" />
         </geometry>
+        <xacro:material_kuka_pedestal />
       </visual>
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0"/>


### PR DESCRIPTION
As per subject.

Collision geometry is using STLs, which don't carry any colour information, so RViz would show red (default colour).

This simply makes the R900 sixx mimic the R700 sixx.
