### PR TITLE
rsi_hw_iface: throw on errors during socket ini

### DIFF
--- a/kuka_rsi_hw_interface/include/kuka_rsi_hw_interface/udp_server.h
+++ b/kuka_rsi_hw_interface/include/kuka_rsi_hw_interface/udp_server.h
@@ -42,10 +42,12 @@
 
 #include <iostream>
 #include <string>
+#include <stdexcept>
 
 // Select includes
 #include <sys/time.h>
 
+#include <string.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -64,9 +66,7 @@ public:
   {
     sockfd_ = socket(AF_INET, SOCK_DGRAM, 0);
     if (sockfd_ < 0)
-    {
-      std::cout << "ERROR opening socket" << std::endl;
-    }
+      throw std::runtime_error("Error opening socket: " + std::string(strerror(errno)));
     optval = 1;
     setsockopt(sockfd_, SOL_SOCKET, SO_REUSEADDR, (const void *)&optval , sizeof(int));
     memset(&serveraddr_, 0, sizeof(serveraddr_));
@@ -74,9 +74,7 @@ public:
     serveraddr_.sin_addr.s_addr = inet_addr(local_host_.c_str());
     serveraddr_.sin_port = htons(local_port_);
     if (bind(sockfd_, (struct sockaddr *) &serveraddr_, sizeof(serveraddr_)) < 0)
-    {
-      std::cout << "ERROR on binding socket" << std::endl;
-    }
+      throw std::runtime_error("Error binding socket: " + std::string(strerror(errno)));
     clientlen_ = sizeof(clientaddr_);
   }
 


### PR DESCRIPTION
As per subject.

The `UDPServer` class could use some TLC in general, but this at least helps with giving more visibility to the more serious errors, such as failing to bind a socket because an incorrect value for `rsi/listen_ip` was supplied.
