### PR TITLE
rsi_hw_iface: use two threads for spinning.

### DIFF
--- a/kuka_rsi_hw_interface/src/kuka_hardware_interface_node.cpp
+++ b/kuka_rsi_hw_interface/src/kuka_hardware_interface_node.cpp
@@ -45,7 +45,7 @@ int main(int argc, char** argv)
 
   ros::init(argc, argv, "kuka_rsi_hardware_interface");
 
-  ros::AsyncSpinner spinner(1);
+  ros::AsyncSpinner spinner(2);
   spinner.start();
 
   ros::NodeHandle nh;


### PR DESCRIPTION
As per subject.

Refer to the `rrbot` implementation for a similar implementation ([here](https://github.com/davetcoleman/ros_control_boilerplate/blob/0fbe7e5343be20f9d6d72020bd58c7904edc3702/rrbot_control/src/rrbot_hw_main.cpp#L47-L50)).
