### PR TITLE
Replace `xacro.py` to `xacro --inorder`

### DIFF
--- a/kuka_eki_hw_interface/krl/README.md
+++ b/kuka_eki_hw_interface/krl/README.md
@@ -42,7 +42,7 @@ We recommend that you copy the configuration files, edit the copies for your nee
 In order to successfully launch the **kuka_eki_hw_interface** a parameter `robot_description` needs to be present on the ROS parameter server. This parameter can be set manually or by adding this line inside the launch file (replace support package and .xacro to match your application):
 
 ```xml
-<param name="robot_description" command="$(find xacro)/xacro.py '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
+<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
 ```
 
 Make sure that the line is added before the `kuka_eki_hw_interface` itself is loaded.

--- a/kuka_kr10_support/launch/load_kr10r1100sixx.launch
+++ b/kuka_kr10_support/launch/load_kr10r1100sixx.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find kuka_kr10_support)/urdf/kr10r1100sixx.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_kr10_support)/urdf/kr10r1100sixx.xacro'"/>
 </launch>

--- a/kuka_kr120_support/launch/load_kr120r2500pro.launch
+++ b/kuka_kr120_support/launch/load_kr120r2500pro.launch
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <launch>
   <!-- Load robot description to parameter server -->
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find kuka_kr120_support)/urdf/kr120r2500pro.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_kr120_support)/urdf/kr120r2500pro.xacro'"/>
 </launch>

--- a/kuka_kr210_support/launch/load_kr210l150.launch
+++ b/kuka_kr210_support/launch/load_kr210l150.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find kuka_kr210_support)/urdf/kr210l150.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_kr210_support)/urdf/kr210l150.xacro'" />
 </launch>

--- a/kuka_kr6_support/launch/load_kr6r700sixx.launch
+++ b/kuka_kr6_support/launch/load_kr6r700sixx.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find kuka_kr6_support)/urdf/kr6r700sixx.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_kr6_support)/urdf/kr6r700sixx.xacro'"/>
 </launch>

--- a/kuka_kr6_support/launch/load_kr6r900sixx.launch
+++ b/kuka_kr6_support/launch/load_kr6r900sixx.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
 </launch>

--- a/kuka_lbr_iiwa_support/launch/load_lbr_iiwa_14_r820.launch
+++ b/kuka_lbr_iiwa_support/launch/load_lbr_iiwa_14_r820.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find kuka_lbr_iiwa_support)/urdf/lbr_iiwa_14_r820.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_lbr_iiwa_support)/urdf/lbr_iiwa_14_r820.xacro'" />
 </launch>

--- a/kuka_rsi_hw_interface/krl/KR_C2/README.md
+++ b/kuka_rsi_hw_interface/krl/KR_C2/README.md
@@ -52,7 +52,7 @@ We recommend that you copy the configuration files, edit the copies for your nee
 In order to successfully launch the **kuka_rsi_hardware_interface** a parameter `robot_description` needs to be present on the ROS parameter server. This parameter can be set manually or by adding this line inside the launch file (replace support package and `.xacro` to match your application):
 
 ```
-<param name="robot_description" command="$(find xacro)/xacro.py '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
+<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
 ```
 
 Make sure that the line is added before the `kuka_hardware_interface` itself is loaded.

--- a/kuka_rsi_hw_interface/krl/KR_C4/README.md
+++ b/kuka_rsi_hw_interface/krl/KR_C4/README.md
@@ -70,7 +70,7 @@ We recommend that you copy the configuration files, edit the copies for your nee
 In order to successfully launch the **kuka_rsi_hardware_interface** a parameter `robot_description` needs to be present on the ROS parameter server. This parameter can be set manually or by adding this line inside the launch file (replace support package and .xacro to match your application):
 
 ```
-<param name="robot_description" command="$(find xacro)/xacro.py '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
+<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
 ```
 
 Make sure that the line is added before the `kuka_hardware_interface` itself is loaded.

--- a/kuka_rsi_hw_interface/test/test_two_robots.launch
+++ b/kuka_rsi_hw_interface/test/test_two_robots.launch
@@ -2,7 +2,7 @@
 <launch>
 
   <group ns="ag1">
-    <param name="robot_description" command="$(find xacro)/xacro.py '$(find kuka_agilus_support)/urdf/agilus.xacro'"/>
+    <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_agilus_support)/urdf/agilus.xacro'"/>
     <!-- Load RSI parameters -->
     <rosparam file="$(find kuka_rsi_hw_interface)/test/ag1_params.yaml" command="load" />
     <!-- Start node -->
@@ -22,7 +22,7 @@
     </group>
 
   <group ns="ag2">
-    <param name="robot_description" command="$(find xacro)/xacro.py '$(find kuka_agilus_support)/urdf/agilus.xacro'"/>
+    <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_agilus_support)/urdf/agilus.xacro'"/>
     <!-- Load RSI parameters -->
     <rosparam file="$(find kuka_rsi_hw_interface)/test/ag2_params.yaml" command="load" />
     <!-- Start node -->


### PR DESCRIPTION
This PR fixes https://github.com/ros-industrial/industrial_training/issues/220 issue.

Environment:
- OS: Ubuntu 16.04
- ROS: Kinetic