### PR TITLE
adding command buffer length to returned RobotState and preventing wr…

### DIFF
--- a/kuka_eki_hw_interface/include/kuka_eki_hw_interface/kuka_eki_hw_interface.h
+++ b/kuka_eki_hw_interface/include/kuka_eki_hw_interface/kuka_eki_hw_interface.h
@@ -65,6 +65,8 @@ private:
   // EKI
   std::string eki_server_address_;
   std::string eki_server_port_;
+  int eki_cmd_buff_len_;
+  int eki_max_cmd_buff_len_ = 5;  // by default, limit command buffer to 5 (size of advance run in KRL)
 
   // Timing
   ros::Duration control_period_;
@@ -85,7 +87,7 @@ private:
   static void eki_handle_receive(const boost::system::error_code &ec, size_t length,
                                  boost::system::error_code* out_ec, size_t* out_length);
   bool eki_read_state(std::vector<double> &joint_position, std::vector<double> &joint_velocity,
-                      std::vector<double> &joint_effort);
+                      std::vector<double> &joint_effort, int &cmd_buff_len);
   bool eki_write_command(const std::vector<double> &joint_position);
 
 public:

--- a/kuka_eki_hw_interface/krl/EkiHwInterface.xml
+++ b/kuka_eki_hw_interface/krl/EkiHwInterface.xml
@@ -64,6 +64,8 @@
          <ELEMENT Tag="RobotState/Eff/@A4"/>
          <ELEMENT Tag="RobotState/Eff/@A5"/>
          <ELEMENT Tag="RobotState/Eff/@A6"/>
+         <!-- Interface state -->
+         <ELEMENT Tag="RobotState/RobotCommand/@Size"/>  <!-- Number of elements currently in command buffer -->
       </XML>
    </SEND>
 </ETHERNETKRL>

--- a/kuka_eki_hw_interface/krl/README.md
+++ b/kuka_eki_hw_interface/krl/README.md
@@ -47,6 +47,11 @@ In order to successfully launch the **kuka_eki_hw_interface** a parameter `robot
 
 Make sure that the line is added before the `kuka_eki_hw_interface` itself is loaded.
 
+##### Command Buffering Setup
+The driver currently limits the number of queued joint targets to prevent unbounded trajectory lag (error) that can occur when sufficiently dense target trajectories (temporal and/or spatial) are requested.  The size of the buffer is set via the parameter `eki/max_cmd_buf_len`.  When not present, the buffer defaults to five (5), which is the maximum number of instructions allowed in the controller's advance run (i.e., KRC internal interpolator lookahead).
+
+With the buffering active, overly dense trajectory points are dropped with the result being small and bounded trajectory lag at the expense of some positional deviation (dropped waypoints are not strictly enforced).  For paths that require exact positional accuracy buffering can be disabled by setting the limit to a sufficiently large number (e.g., 512) with the caveat that dense trajectories might result in low-than-requested velocity and subsequent time lag.  In other words, the buffering limit can be seen as a tradeoff between positional accuracy and time accuracy.
+
 ## 4. Testing
 At this point you are ready to test the EKI interface. Before the test, make sure that:
 

--- a/kuka_eki_hw_interface/krl/kuka_eki_hw_interface.src
+++ b/kuka_eki_hw_interface/krl/kuka_eki_hw_interface.src
@@ -127,6 +127,9 @@ def eki_hw_iface_send()
       ;eki_ret = eki_setreal("EkiHwInterface", "RobotState/Eff/@A4", $torque_axis_act[4])
       ;eki_ret = eki_setreal("EkiHwInterface", "RobotState/Eff/@A5", $torque_axis_act[5])
       ;eki_ret = eki_setreal("EkiHwInterface", "RobotState/Eff/@A6", $torque_axis_act[6])
+      ; interface state
+      eki_ret = eki_checkbuffer("EkiHwInterface", "RobotCommand/Pos/@A1")
+      eki_ret = eki_setint("EkiHwInterface", "RobotState/RobotCommand/@Size", eki_ret.buff)
 
       ; Send xml structure
       if $flag[1] then  ; Make sure connection hasn't died while updating xml structure

--- a/kuka_eki_hw_interface/src/kuka_eki_hw_interface.cpp
+++ b/kuka_eki_hw_interface/src/kuka_eki_hw_interface.cpp
@@ -292,6 +292,9 @@ void KukaEkiHardwareInterface::write(const ros::Time &time, const ros::Duration 
     eki_write_command(joint_position_command_);
 
   // underflow/overflow checking
+  // NOTE: this is commented as it results in a lot of logging output and the use of ROS_*
+  //       logging macros breaks incurs (quite) some overhead. Uncomment and rebuild this
+  //       if you'd like to use this anyway.
   //if (eki_cmd_buff_len_ >= eki_max_cmd_buff_len_)
   //  ROS_WARN_STREAM("eki_hw_iface RobotCommand buffer overflow (curent size " << eki_cmd_buff_len_
   //                  << " greater than or equal max allowed " << eki_max_cmd_buff_len_ << ")");

--- a/kuka_eki_hw_interface/src/kuka_eki_hw_interface.cpp
+++ b/kuka_eki_hw_interface/src/kuka_eki_hw_interface.cpp
@@ -81,7 +81,8 @@ void KukaEkiHardwareInterface::eki_handle_receive(const boost::system::error_cod
 
 bool KukaEkiHardwareInterface::eki_read_state(std::vector<double> &joint_position,
                                               std::vector<double> &joint_velocity,
-                                              std::vector<double> &joint_effort)
+                                              std::vector<double> &joint_effort,
+                                              int &cmd_buff_len)
 {
   static boost::array<char, 2048> in_buffer;
 
@@ -112,7 +113,8 @@ bool KukaEkiHardwareInterface::eki_read_state(std::vector<double> &joint_positio
   TiXmlElement* pos = robot_state->FirstChildElement("Pos");
   TiXmlElement* vel = robot_state->FirstChildElement("Vel");
   TiXmlElement* eff = robot_state->FirstChildElement("Eff");
-  if (!pos || !vel || !eff)
+  TiXmlElement* robot_command = robot_state->FirstChildElement("RobotCommand");
+  if (!pos || !vel || !eff || !robot_command)
     return false;
 
   // Extract axis positions
@@ -130,6 +132,9 @@ bool KukaEkiHardwareInterface::eki_read_state(std::vector<double> &joint_positio
     joint_effort[i] = joint_eff;
     axis_name[1]++;
   }
+
+  // Extract number of command elements buffered on robot
+  robot_command->Attribute("Size", &cmd_buff_len);
 
   return true;
 }
@@ -175,6 +180,7 @@ void KukaEkiHardwareInterface::init()
   const std::string param_addr = "eki/robot_address";
   const std::string param_port = "eki/robot_port";
   const std::string param_socket_timeout = "eki/socket_timeout";
+  const std::string param_max_cmd_buf_len = "eki/max_cmd_buf_len";
 
   if (nh_.getParam(param_addr, eki_server_address_) &&
       nh_.getParam(param_port, eki_server_port_))
@@ -200,6 +206,18 @@ void KukaEkiHardwareInterface::init()
     ROS_INFO_STREAM_NAMED("kuka_eki_hw_interface", "Failed to get EKI socket timeout from parameter server (looking "
                           "for '" + param_socket_timeout + "'), defaulting to " +
                           std::to_string(eki_read_state_timeout_)  + " seconds");
+  }
+
+  if (nh_.getParam(param_max_cmd_buf_len, eki_max_cmd_buff_len_))
+  {
+    ROS_INFO_STREAM_NAMED("kuka_eki_hw_interface", "Configuring Kuka EKI hardware interface maximum command buffer "
+                          "length to " << eki_max_cmd_buff_len_);
+  }
+  else
+  {
+    ROS_INFO_STREAM_NAMED("kuka_eki_hw_interface", "Failed to get EKI hardware interface maximum command buffer length "
+                          "from parameter server (looking for '" + param_max_cmd_buf_len + "'), defaulting to " +
+                          std::to_string(eki_max_cmd_buff_len_));
   }
 
   // Create ros_control interfaces (joint state and position joint for all dof's)
@@ -240,7 +258,7 @@ void KukaEkiHardwareInterface::start()
   eki_check_read_state_deadline();
 
   // Initialize joint_position_command_ from initial robot state (avoid bad (null) commands before controllers come up)
-  if (!eki_read_state(joint_position_, joint_velocity_, joint_effort_))
+  if (!eki_read_state(joint_position_, joint_velocity_, joint_effort_, eki_cmd_buff_len_))
   {
     std::string msg = "Failed to read from robot EKI server within alloted time of "
                       + std::to_string(eki_read_state_timeout_) + " seconds.  Make sure eki_hw_interface is running "
@@ -256,7 +274,7 @@ void KukaEkiHardwareInterface::start()
 
 void KukaEkiHardwareInterface::read(const ros::Time &time, const ros::Duration &period)
 {
-  if (!eki_read_state(joint_position_, joint_velocity_, joint_effort_))
+  if (!eki_read_state(joint_position_, joint_velocity_, joint_effort_, eki_cmd_buff_len_))
   {
     std::string msg = "Failed to read from robot EKI server within alloted time of "
                       + std::to_string(eki_read_state_timeout_) + " seconds.  Make sure eki_hw_interface is running "
@@ -269,7 +287,16 @@ void KukaEkiHardwareInterface::read(const ros::Time &time, const ros::Duration &
 
 void KukaEkiHardwareInterface::write(const ros::Time &time, const ros::Duration &period)
 {
-  eki_write_command(joint_position_command_);
+  // only write if max will not be exceeded
+  if (eki_cmd_buff_len_ < eki_max_cmd_buff_len_)
+    eki_write_command(joint_position_command_);
+
+  // underflow/overflow checking
+  //if (eki_cmd_buff_len_ >= eki_max_cmd_buff_len_)
+  //  ROS_WARN_STREAM("eki_hw_iface RobotCommand buffer overflow (curent size " << eki_cmd_buff_len_
+  //                  << " greater than or equal max allowed " << eki_max_cmd_buff_len_ << ")");
+  //else if (eki_cmd_buff_len_ == 0)
+  //  ROS_WARN_STREAM("eki_hw_iface RobotCommand buffer empty");
 }
 
 } // namespace kuka_eki_hw_interface


### PR DESCRIPTION
…iting when (configurable) max exceeded

Fixes #142 by preventing writes when buffer exceeds specified limit (via eki/max_cmd_buf_len parameter (defaults to 5)).  This prevents small/trivial moves from overwhelming the ptp lookahead via the advance run.  With the new limits, time lag is now small and bounded but at the expense of small positional blending error.  The original behavior can be restored by setting the new limit parameter sufficiently large.