### PR TITLE
Indigo ci

### DIFF
--- a/.github/workflows/ci_trusty.yml
+++ b/.github/workflows/ci_trusty.yml
@@ -1,0 +1,48 @@
+name: CI - Ubuntu Trusty
+
+on:
+  # direct pushes to protected branches are not supported
+  pull_request:
+  # run every day, at 6am UTC
+  schedule:
+    - cron: '0 6 * * *'
+  # allow manually starting this workflow
+  workflow_dispatch:
+
+jobs:
+  industrial_ci:
+    name: ROS Indigo (${{ matrix.ros_repo }})
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ros_distro: [ indigo ]
+        ros_repo: [ main ]
+
+    env:
+      CCACHE_DIR: "${{ github.workspace }}/.ccache"
+      CATKIN_LINT: true
+      CATKIN_LINT_ARGS: --ignore launch_depend --ignore uninstalled_include_path --ignore critical_var_append
+
+    steps:
+      - name: Fetch repository
+        uses: actions/checkout@v2
+
+      - name: ccache cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          # we always want the ccache cache to be persisted, as we cannot easily
+          # determine whether dependencies have changed, and ccache will manage
+          # updating the cache for us. Adding 'run_id' to the key will force an
+          # upload at the end of the job.
+          key: ccache-${{ matrix.ros_distro }}-${{ matrix.ros_repo }}-${{github.run_id}}
+          restore-keys: |
+            ccache-${{ matrix.ros_distro }}-${{ matrix.ros_repo }}
+
+      - name: Run industrial_ci
+        uses: ros-industrial/industrial_ci@master
+        env:
+          ROS_DISTRO: ${{ matrix.ros_distro }}
+          ROS_REPO: ${{ matrix.ros_repo }}

--- a/.github/workflows/ci_trusty.yml
+++ b/.github/workflows/ci_trusty.yml
@@ -3,9 +3,6 @@ name: CI - Ubuntu Trusty
 on:
   # direct pushes to protected branches are not supported
   pull_request:
-  # run every day, at 6am UTC
-  schedule:
-    - cron: '0 6 * * *'
   # allow manually starting this workflow
   workflow_dispatch:
 

--- a/.github/workflows/ci_trusty.yml
+++ b/.github/workflows/ci_trusty.yml
@@ -22,8 +22,7 @@ jobs:
 
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
-      CATKIN_LINT: true
-      CATKIN_LINT_ARGS: --ignore launch_depend --ignore uninstalled_include_path --ignore critical_var_append
+      CATKIN_LINT: false
 
     steps:
       - name: Fetch repository

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Kuka experimental
 
 [![Build Status](http://build.ros.org/job/Kdev__kuka_experimental__ubuntu_xenial_amd64/badge/icon)](http://build.ros.org/job/Kdev__kuka_experimental__ubuntu_xenial_amd64)
+[![Build Status: Ubuntu Trusty (Actions)](https://github.com/ros-industrial/kuka_experimental/workflows/CI%20-%20Ubuntu%20Trusty/badge.svg?branch=indigo-devel)](https://github.com/ros-industrial/kuka_experimental/actions?query=workflow%3A%22CI+-+Ubuntu+Trusty%22)
 [![Build Status: Ubuntu Xenial (Actions)](https://github.com/ros-industrial/kuka_experimental/workflows/CI%20-%20Ubuntu%20Xenial/badge.svg?branch=indigo-devel)](https://github.com/ros-industrial/kuka_experimental/actions?query=workflow%3A%22CI+-+Ubuntu+Xenial%22)
 [![Build Status: Ubuntu Bionic (Actions)](https://github.com/ros-industrial/kuka_experimental/workflows/CI%20-%20Ubuntu%20Bionic/badge.svg?branch=indigo-devel)](https://github.com/ros-industrial/kuka_experimental/actions?query=workflow%3A%22CI+-+Ubuntu+Bionic%22)
 

--- a/kuka_eki_hw_interface/krl/README.md
+++ b/kuka_eki_hw_interface/krl/README.md
@@ -42,7 +42,7 @@ We recommend that you copy the configuration files, edit the copies for your nee
 In order to successfully launch the **kuka_eki_hw_interface** a parameter `robot_description` needs to be present on the ROS parameter server. This parameter can be set manually or by adding this line inside the launch file (replace support package and .xacro to match your application):
 
 ```xml
-<param name="robot_description" command="$(find xacro)/xacro '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
+<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
 ```
 
 Make sure that the line is added before the `kuka_eki_hw_interface` itself is loaded.

--- a/kuka_kr10_support/launch/load_kr10r1100sixx.launch
+++ b/kuka_kr10_support/launch/load_kr10r1100sixx.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find kuka_kr10_support)/urdf/kr10r1100sixx.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_kr10_support)/urdf/kr10r1100sixx.xacro'"/>
 </launch>

--- a/kuka_kr10_support/launch/load_kr10r900_2.launch
+++ b/kuka_kr10_support/launch/load_kr10r900_2.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find kuka_kr10_support)/urdf/kr10r900_2.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_kr10_support)/urdf/kr10r900_2.xacro'"/>
 </launch>

--- a/kuka_kr120_support/launch/load_kr120r2500pro.launch
+++ b/kuka_kr120_support/launch/load_kr120r2500pro.launch
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <launch>
   <!-- Load robot description to parameter server -->
-  <param name="robot_description" command="$(find xacro)/xacro '$(find kuka_kr120_support)/urdf/kr120r2500pro.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_kr120_support)/urdf/kr120r2500pro.xacro'"/>
 </launch>

--- a/kuka_kr210_support/launch/load_kr210l150.launch
+++ b/kuka_kr210_support/launch/load_kr210l150.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find kuka_kr210_support)/urdf/kr210l150.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_kr210_support)/urdf/kr210l150.xacro'" />
 </launch>

--- a/kuka_kr6_support/launch/load_kr6r700sixx.launch
+++ b/kuka_kr6_support/launch/load_kr6r700sixx.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find kuka_kr6_support)/urdf/kr6r700sixx.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_kr6_support)/urdf/kr6r700sixx.xacro'"/>
 </launch>

--- a/kuka_kr6_support/launch/load_kr6r900sixx.launch
+++ b/kuka_kr6_support/launch/load_kr6r900sixx.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
 </launch>

--- a/kuka_lbr_iiwa_support/launch/load_lbr_iiwa_14_r820.launch
+++ b/kuka_lbr_iiwa_support/launch/load_lbr_iiwa_14_r820.launch
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro '$(find kuka_lbr_iiwa_support)/urdf/lbr_iiwa_14_r820.xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_lbr_iiwa_support)/urdf/lbr_iiwa_14_r820.xacro'" />
 </launch>

--- a/kuka_rsi_hw_interface/krl/KR_C2/README.md
+++ b/kuka_rsi_hw_interface/krl/KR_C2/README.md
@@ -52,7 +52,7 @@ We recommend that you copy the configuration files, edit the copies for your nee
 In order to successfully launch the **kuka_rsi_hardware_interface** a parameter `robot_description` needs to be present on the ROS parameter server. This parameter can be set manually or by adding this line inside the launch file (replace support package and `.xacro` to match your application):
 
 ```
-<param name="robot_description" command="$(find xacro)/xacro '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
+<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
 ```
 
 Make sure that the line is added before the `kuka_hardware_interface` itself is loaded.

--- a/kuka_rsi_hw_interface/krl/KR_C4/README.md
+++ b/kuka_rsi_hw_interface/krl/KR_C4/README.md
@@ -70,7 +70,7 @@ We recommend that you copy the configuration files, edit the copies for your nee
 In order to successfully launch the **kuka_rsi_hardware_interface** a parameter `robot_description` needs to be present on the ROS parameter server. This parameter can be set manually or by adding this line inside the launch file (replace support package and .xacro to match your application):
 
 ```
-<param name="robot_description" command="$(find xacro)/xacro '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
+<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find kuka_kr6_support)/urdf/kr6r900sixx.xacro'"/>
 ```
 
 Make sure that the line is added before the `kuka_hardware_interface` itself is loaded.


### PR DESCRIPTION
I slightly messed up `indigo` compatibility when merging #199 instead of #139  to `indigo-devel`. This restores compatibility with `indigo` (it has been "broken" already since at least 2018 however) and enables CI for it to prevent future regressions