### PR TITLE
Python 3 compatibility for kuka_rsi_simulator under Noetic

### DIFF
--- a/kuka_rsi_simulator/scripts/kuka_rsi_simulator
+++ b/kuka_rsi_simulator/scripts/kuka_rsi_simulator
@@ -85,10 +85,9 @@ if __name__ == '__main__':
             act_joint_pos = cmd_joint_pos + des_joint_correction_absolute
             ipoc += 1
             time.sleep(cycle_time / 2)
-        except socket.timeout, msg:
+        except socket.timeout as msg:
             rospy.logwarn('{}: Socket timed out'.format(node_name))
             timeout_count += 1
-        except socket.error, e:
+        except socket.error as e:
             if e.errno != errno.EINTR:
                 raise
-


### PR DESCRIPTION
the `kuka_rsi_simulator` needed a couple changes to run under Noetic, this is backward compatible with Python 2.7.